### PR TITLE
Upgrade to speedtest-exporter@v0.1.0

### DIFF
--- a/charts/speedtest-exporter/Chart.yaml
+++ b/charts/speedtest-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: speedtest-exporter
 description: A Helm chart for deploying speedtest-exporter
 type: application
-version: 0.0.6
-appVersion: "v0.0.1"
+version: 0.1.0
+appVersion: "v0.1.0"
 home: https://github.com/timebertt/helm-charts/charts/isp-monitor
 sources:
 - https://github.com/timebertt/speedtest-exporter

--- a/charts/speedtest-exporter/values.yaml
+++ b/charts/speedtest-exporter/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/timebertt/speedtest-exporter
-  tag: v0.0.1
+  tag: v0.1.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Upgrade to [speedtest-exporter@v0.1.0](https://github.com/timebertt/speedtest-exporter/releases/tag/v0.1.0):

- Build `linux/arm64` images: timebertt/speedtest-exporter#1