### PR TITLE
Fix ICMP and TCP Probes

### DIFF
--- a/charts/isp-monitor/Chart.yaml
+++ b/charts/isp-monitor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: isp-monitor
 description: A Helm Chart for deploying ISP monitoring
 type: application
-version: 0.3.0
-appVersion: "v0.3.0"
+version: 0.3.1
+appVersion: "v0.3.1"
 home: https://github.com/timebertt/helm-charts/charts/isp-monitor
 sources:
 - https://github.com/timebertt/helm-charts/charts/isp-monitor

--- a/charts/isp-monitor/dashboards/isp-monitor.json
+++ b/charts/isp-monitor/dashboards/isp-monitor.json
@@ -924,7 +924,8 @@
     },
     {
       "aliasColors": {
-        "{instance=\"speedtest-exporter:8650\"}": "rgb(0, 0, 0)"
+        "{instance=\"speedtest-exporter:8650\"}": "rgb(0, 0, 0)",
+        "{mode=\"go\"}": "rgb(0, 0, 0)"
       },
       "bars": false,
       "dashLength": 10,
@@ -972,7 +973,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(speedtest_download_speed_mbps) by (instance)",
+          "expr": "sum(speedtest_download_speed_mbps) by (mode)",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/charts/isp-monitor/templates/configmap-probe-targets.yaml
+++ b/charts/isp-monitor/templates/configmap-probe-targets.yaml
@@ -25,7 +25,7 @@ data:
         network: internet
     - targets: [ "1.1.1.1" ]
       labels:
-        target: google-dns-1-1-1-1
+        target: cloudflare-dns-1-1-1-1
         network: internet
         __http_probe: no
         __tcp_probe: no

--- a/charts/isp-monitor/values.yaml
+++ b/charts/isp-monitor/values.yaml
@@ -94,6 +94,12 @@ prometheus:
         regex: no
         action: drop
       - source_labels: [__address__]
+        regex: https://(.*)
+        replacement: $1:443
+        target_label: __param_target
+      - source_labels: [__address__]
+        regex: http://(.*)
+        replacement: $1:80
         target_label: __param_target
       - target_label: __address__
         replacement: blackbox-exporter:9115
@@ -119,6 +125,8 @@ prometheus:
 prometheus-blackbox-exporter:
   fullnameOverride: blackbox-exporter
 
+  allowIcmp: true
+
   config:
     modules:
       http_2xx:
@@ -134,12 +142,12 @@ prometheus-blackbox-exporter:
       icmp:
         prober: icmp
         timeout: 5s
-        icmp: 
+        icmp:
           preferred_ip_protocol: "ip4"
       dns:
         prober: dns
         timeout: 5s
-        dns: 
+        dns:
           preferred_ip_protocol: "ip4"
           query_name: google.com
 


### PR DESCRIPTION
Fixes ICMP probes by setting `blackbox-exporter.allowIcmp=true` (will add `CAP_NET_RAW`).
Fixes TCP probes by adding `:{80,443}` to target address.
Fixes grouping/coloring for `Download Speed Over Time` Panel.