### PR TITLE
Add Octobox chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 .vscode
 /dev
-/charts/*/charts
-*.tgz
+**/charts/*.tgz
 *.secret.yaml

--- a/charts/octobox/.helmignore
+++ b/charts/octobox/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+*.secret.yaml

--- a/charts/octobox/Chart.lock
+++ b/charts/octobox/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 13.0.1
-digest: sha256:c1628d0664a6f9bdf506f812ce59071a0d64fac51dadda0591fe90e472dc89fa
-generated: "2021-04-14T12:01:44.366295+02:00"
+- name: nginx
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.8.3
+digest: sha256:63fe1d8fb466bdb92077f047b08ef9f7bee05f1bfd8bde3ba0b7e7e97702aa8c
+generated: "2021-04-18T18:26:05.988191+02:00"

--- a/charts/octobox/Chart.lock
+++ b/charts/octobox/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.17
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.0.1
+digest: sha256:c1628d0664a6f9bdf506f812ce59071a0d64fac51dadda0591fe90e472dc89fa
+generated: "2021-04-14T12:01:44.366295+02:00"

--- a/charts/octobox/Chart.yaml
+++ b/charts/octobox/Chart.yaml
@@ -23,3 +23,8 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled, global.redis.enabled
   alias: redis
+- name: nginx
+  version: "8.8.*"
+  repository: https://charts.bitnami.com/bitnami
+  condition: nginx.enabled, global.nginx.enabled
+  alias: nginx

--- a/charts/octobox/Chart.yaml
+++ b/charts/octobox/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: octobox
+description: A Helm chart for deploying Octobox
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/timebertt/helm-charts/charts/octobox
+sources:
+- https://github.com/timebertt/helm-charts/charts/octobox
+keywords:
+- octobox
+- github
+- notifications
+dependencies:
+- name: postgresql
+  version: "10.3.*"
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled, global.postgresql.enabled
+  import-values: # (optional)
+  # - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
+  alias: postgresql
+- name: redis
+  version: "13.0.*"
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled, global.redis.enabled
+  tags: # (optional)
+  #  - Tags can be used to group charts for enabling/disabling together
+  import-values: # (optional)
+  # - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
+  alias: redis

--- a/charts/octobox/Chart.yaml
+++ b/charts/octobox/Chart.yaml
@@ -4,8 +4,9 @@ description: A Helm chart for deploying Octobox
 type: application
 version: 0.1.0
 appVersion: "latest"
-home: https://github.com/timebertt/helm-charts/charts/octobox
+home: https://github.com/octobox/octobox
 sources:
+- https://github.com/octobox/octobox
 - https://github.com/timebertt/helm-charts/charts/octobox
 keywords:
 - octobox
@@ -16,15 +17,9 @@ dependencies:
   version: "10.3.*"
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled, global.postgresql.enabled
-  import-values: # (optional)
-  # - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
   alias: postgresql
 - name: redis
   version: "13.0.*"
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled, global.redis.enabled
-  tags: # (optional)
-  #  - Tags can be used to group charts for enabling/disabling together
-  import-values: # (optional)
-  # - ImportValues holds the mapping of source values to parent key to be imported. Each item can be a string or pair of child/parent sublist items.
   alias: redis

--- a/charts/octobox/templates/NOTES.txt
+++ b/charts/octobox/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "octobox.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "octobox.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "octobox.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "octobox.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/octobox/templates/_helpers.tpl
+++ b/charts/octobox/templates/_helpers.tpl
@@ -1,0 +1,101 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "octobox.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "octobox.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "octobox.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "octobox.labels" -}}
+helm.sh/chart: {{ include "octobox.chart" . }}
+{{ include "octobox.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "octobox.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "octobox.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return secret name (either fullname or existingSecret if specified)
+*/}}
+{{- define "octobox.secretName" -}}
+{{- $fullName := include "octobox.fullname" . -}}
+{{- default $fullName .Values.existingSecret | quote -}}
+{{- end -}}
+
+{{/*
+Return configmap name (either fullname or existingConfigMap if specified)
+*/}}
+{{- define "octobox.configMapName" -}}
+{{- $fullName := include "octobox.fullname" . -}}
+{{- default $fullName .Values.existingConfigMap | quote -}}
+{{- end -}}
+
+{{/*
+Return postgres host (from postgresql values or overwrite if specified)
+*/}}
+{{- define "octobox.postgresHost" -}}
+{{- if .Values.config.octoboxDatabaseHost -}}
+{{ .Values.config.octoboxDatabaseHost -}}
+{{- else -}}
+{{- $postgresFullname := "postgres" -}}
+{{- with (set (deepCopy .) "Values" .Values.postgresql) -}}
+{{- $postgresFullname := include "common.names.fullname" . -}}
+{{- end -}}
+{{ printf "%s.%s" $postgresFullname .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return redis connection URL (from redis values or overwrite if specified)
+*/}}
+{{- define "octobox.redisURL" -}}
+{{- if .Values.secrets.redisURL -}}
+{{- .Values.secrets.redisURL -}}
+{{- else -}}
+{{- $redisURL := "redis://" -}}
+{{- if and .Values.redis.usePassword .Values.redis.password -}}
+{{- $redisURL = printf "%s:%s@" $redisURL .Values.redis.password -}}
+{{- end -}}
+{{- $redisFullname := "redis" -}}
+{{- with (set (deepCopy .) "Values" .Values.redis) -}}
+{{- $redisFullname := include "redis.fullname" . -}}
+{{- end -}}
+{{- printf "%s%s-master.%s:%s" $redisURL $redisFullname .Release.Namespace (toString .Values.redis.master.service.port) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/octobox/templates/_helpers.tpl
+++ b/charts/octobox/templates/_helpers.tpl
@@ -62,11 +62,11 @@ Return secret name (either fullname or existingSecret if specified)
 Return image reference (either using tag or sha)
 */}}
 {{- define "octobox.image" -}}
-{{- .Values.image.repository -}}
-{{- if hasPrefix "sha256:" .Values.image.tag -}}
-@{{- .Values.image.tag -}}
+{{- .Values.global.octobox.image.repository -}}
+{{- if hasPrefix "sha256:" .Values.global.octobox.image.tag -}}
+@{{- .Values.global.octobox.image.tag -}}
 {{- else -}}
-:{{- .Values.image.tag | default .Chart.AppVersion -}}
+:{{- .Values.global.octobox.image.tag | default .Chart.AppVersion -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/octobox/templates/_helpers.tpl
+++ b/charts/octobox/templates/_helpers.tpl
@@ -59,6 +59,18 @@ Return secret name (either fullname or existingSecret if specified)
 {{- end -}}
 
 {{/*
+Return image reference (either using tag or sha)
+*/}}
+{{- define "octobox.image" -}}
+{{- .Values.image.repository -}}
+{{- if hasPrefix "sha256:" .Values.image.tag -}}
+@{{- .Values.image.tag -}}
+{{- else -}}
+:{{- .Values.image.tag | default .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return configmap name (either fullname or existingConfigMap if specified)
 */}}
 {{- define "octobox.configMapName" -}}

--- a/charts/octobox/templates/_helpers.tpl
+++ b/charts/octobox/templates/_helpers.tpl
@@ -96,6 +96,10 @@ Return redis connection URL (from redis values or overwrite if specified)
 {{- with (set (deepCopy .) "Values" .Values.redis) -}}
 {{- $redisFullname := include "redis.fullname" . -}}
 {{- end -}}
-{{- printf "%s%s-master.%s:%s" $redisURL $redisFullname .Release.Namespace (toString .Values.redis.master.service.port) -}}
+{{- $redisHost := print $redisFullname "-master" -}}
+{{- if .Values.redis.sentinel.enabled -}}
+{{- $redisHost = $redisFullname -}}
+{{- end -}}
+{{- printf "%s%s.%s:%s" $redisURL $redisHost .Release.Namespace (toString .Values.redis.master.service.port) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/octobox/templates/_helpers.tpl
+++ b/charts/octobox/templates/_helpers.tpl
@@ -70,8 +70,8 @@ Return configmap name (either fullname or existingConfigMap if specified)
 Return postgres host (from postgresql values or overwrite if specified)
 */}}
 {{- define "octobox.postgresHost" -}}
-{{- if .Values.config.octoboxDatabaseHost -}}
-{{ .Values.config.octoboxDatabaseHost -}}
+{{- if .Values.config.database.host -}}
+{{ .Values.config.database.host -}}
 {{- else -}}
 {{- $postgresFullname := "postgres" -}}
 {{- with (set (deepCopy .) "Values" .Values.postgresql) -}}
@@ -85,8 +85,8 @@ Return postgres host (from postgresql values or overwrite if specified)
 Return redis connection URL (from redis values or overwrite if specified)
 */}}
 {{- define "octobox.redisURL" -}}
-{{- if .Values.secrets.redisURL -}}
-{{- .Values.secrets.redisURL -}}
+{{- if .Values.config.redisURL -}}
+{{- .Values.config.redisURL -}}
 {{- else -}}
 {{- $redisURL := "redis://" -}}
 {{- if and .Values.redis.usePassword .Values.redis.password -}}

--- a/charts/octobox/templates/configmap.yaml
+++ b/charts/octobox/templates/configmap.yaml
@@ -1,0 +1,57 @@
+{{- if not .Values.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+data:
+  DATABASE: {{ .Values.config.database | required "config.database is required" | quote }}
+
+  OCTOBOX_DATABASE_HOST: {{ include "octobox.postgresHost" . | quote }}
+  {{- if .Values.config.octoboxDatabasePort }}
+  OCTOBOX_DATABASE_PORT: {{ .Values.config.octoboxDatabasePort | quote }}
+  {{- else }}
+  OCTOBOX_DATABASE_PORT: {{ .Values.postgresql.service.port | quote }}
+  {{- end }}
+  {{- if .Values.config.octoboxDatabaseName }}
+  OCTOBOX_DATABASE_NAME: {{ .Values.config.octoboxDatabaseName | quote }}
+  {{- else }}
+  OCTOBOX_DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase | quote }}
+  {{- end }}
+
+  FETCH_SUBJECT: {{ .Values.config.fetchSubject | quote }}
+
+  {{- with .Values.config.githubScope }}
+  GITHUB_SCOPE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.githubDomain }}
+  GITHUB_DOMAIN: {{ . | quote }}
+  {{- end }}
+
+  GA_ANALYTICS_ID: {{ .Values.config.gaAnalyticsID | quote }}
+  MINIMUM_REFRESH_INTERVAL: {{ .Values.config.minimumRefreshInterval | toString | quote }}
+  OPEN_IN_SAME_TAB: {{ .Values.config.openInSameTab | quote }}
+  PERSONAL_ACCESS_TOKENS_ENABLED: {{ .Values.config.personalAccessTokensEnabled | quote }}
+  RAILS_ENV: {{ .Values.config.railsEnv | quote }}
+  RAILS_SERVE_STATIC_FILES: {{ .Values.config.railsServeStaticAssets | quote }}
+
+  PUSH_NOTIFICATIONS: {{ .Values.config.pushNotifications | quote }}
+  {{- with .Values.config.websocketAllowedOrigins }}
+  WEBSOCKET_ALLOWED_ORIGINS: {{ . | join "," | quote }}
+  {{- end }}
+
+  {{- if .Values.config.restrictedAccess.enabled }}
+  RESTRICTED_ACCESS_ENABLED: "true"
+  {{- with .Values.config.restrictedAccess.githubOrganizationID }}
+  GITHUB_ORGANIZATION_ID: {{ . | toString | quote }}
+  {{- end }}
+  {{- with .Values.config.restrictedAccess.githubTeamID }}
+  GITHUB_TEAM_ID: {{ . | toString | quote }}
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.config.adminGithubIDs }}
+  ADMIN_GITHUB_IDS: {{ . | join "," | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/octobox/templates/configmap.yaml
+++ b/charts/octobox/templates/configmap.yaml
@@ -6,52 +6,57 @@ metadata:
   labels:
     {{- include "octobox.labels" . | nindent 4 }}
 data:
-  DATABASE: {{ .Values.config.database | required "config.database is required" | quote }}
+  DATABASE: "postgres"
 
   OCTOBOX_DATABASE_HOST: {{ include "octobox.postgresHost" . | quote }}
-  {{- if .Values.config.octoboxDatabasePort }}
-  OCTOBOX_DATABASE_PORT: {{ .Values.config.octoboxDatabasePort | quote }}
+  {{- if .Values.config.database.port }}
+  OCTOBOX_DATABASE_PORT: {{ .Values.config.database.port | quote }}
   {{- else }}
   OCTOBOX_DATABASE_PORT: {{ .Values.postgresql.service.port | quote }}
   {{- end }}
-  {{- if .Values.config.octoboxDatabaseName }}
-  OCTOBOX_DATABASE_NAME: {{ .Values.config.octoboxDatabaseName | quote }}
+  {{- if .Values.config.database.databaseName }}
+  OCTOBOX_DATABASE_NAME: {{ .Values.config.database.databaseName | quote }}
   {{- else }}
   OCTOBOX_DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase | quote }}
   {{- end }}
 
-  FETCH_SUBJECT: {{ .Values.config.fetchSubject | quote }}
-
-  {{- with .Values.config.githubScope }}
-  GITHUB_SCOPE: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.config.githubDomain }}
+  {{- with .Values.config.github.domain }}
   GITHUB_DOMAIN: {{ . | quote }}
   {{- end }}
-
-  GA_ANALYTICS_ID: {{ .Values.config.gaAnalyticsID | quote }}
-  MINIMUM_REFRESH_INTERVAL: {{ .Values.config.minimumRefreshInterval | toString | quote }}
-  OPEN_IN_SAME_TAB: {{ .Values.config.openInSameTab | quote }}
-  PERSONAL_ACCESS_TOKENS_ENABLED: {{ .Values.config.personalAccessTokensEnabled | quote }}
-  RAILS_ENV: {{ .Values.config.railsEnv | quote }}
-  RAILS_SERVE_STATIC_FILES: {{ .Values.config.railsServeStaticAssets | quote }}
-
-  PUSH_NOTIFICATIONS: {{ .Values.config.pushNotifications | quote }}
-  {{- with .Values.config.websocketAllowedOrigins }}
-  WEBSOCKET_ALLOWED_ORIGINS: {{ . | join "," | quote }}
+  {{- with .Values.config.github.oauth.scope }}
+  GITHUB_SCOPE: {{ . | quote }}
   {{- end }}
 
-  {{- if .Values.config.restrictedAccess.enabled }}
+  PERSONAL_ACCESS_TOKENS_ENABLED: {{ .Values.config.github.personalAccessTokensEnabled | quote }}
+
+  {{- if .Values.config.github.restrictedAccess.enabled }}
   RESTRICTED_ACCESS_ENABLED: "true"
-  {{- with .Values.config.restrictedAccess.githubOrganizationID }}
+  {{- with .Values.config.github.restrictedAccess.organizationID }}
   GITHUB_ORGANIZATION_ID: {{ . | toString | quote }}
   {{- end }}
-  {{- with .Values.config.restrictedAccess.githubTeamID }}
+  {{- with .Values.config.github.restrictedAccess.teamID }}
   GITHUB_TEAM_ID: {{ . | toString | quote }}
   {{- end }}
   {{- end }}
 
-  {{- with .Values.config.adminGithubIDs }}
+  {{- with .Values.config.github.adminIDs }}
   ADMIN_GITHUB_IDS: {{ . | join "," | quote }}
   {{- end }}
+
+  FETCH_SUBJECT: {{ .Values.config.fetchSubject | quote }}
+  INCLUDE_COMMENTS: {{ .Values.config.includeComments | quote }}
+  OPEN_IN_SAME_TAB: {{ .Values.config.openInSameTab | quote }}
+  MINIMUM_REFRESH_INTERVAL: {{ .Values.config.minimumRefreshInterval | toString | quote }}
+
+  RAILS_ENV: {{ .Values.config.railsEnv | quote }}
+  RAILS_SERVE_STATIC_FILES: {{ .Values.config.railsServeStaticAssets | quote }}
+
+  {{- if .Values.config.pushNotifications }}
+  PUSH_NOTIFICATIONS: "true"
+  {{- with .Values.config.websocketAllowedOrigins }}
+  WEBSOCKET_ALLOWED_ORIGINS: {{ . | join "," | quote }}
+  {{- end }}
+  {{- end }}
+
+  GA_ANALYTICS_ID: {{ .Values.config.googleAnalyticsID | quote }}
 {{- end }}

--- a/charts/octobox/templates/configmap.yaml
+++ b/charts/octobox/templates/configmap.yaml
@@ -17,7 +17,9 @@ data:
   {{- if .Values.config.database.databaseName }}
   OCTOBOX_DATABASE_NAME: {{ .Values.config.database.databaseName | quote }}
   {{- else }}
-  OCTOBOX_DATABASE_NAME: {{ .Values.postgresql.postgresqlDatabase | quote }}
+  {{- with (set (deepCopy .) "Values" .Values.postgresql) }}
+  OCTOBOX_DATABASE_NAME: {{ include "postgresql.database" . | quote }}
+  {{- end }}
   {{- end }}
 
   {{- with .Values.config.github.domain }}

--- a/charts/octobox/templates/configmap.yaml
+++ b/charts/octobox/templates/configmap.yaml
@@ -29,6 +29,13 @@ data:
   GITHUB_SCOPE: {{ . | quote }}
   {{- end }}
 
+  {{- if .Values.config.github.app }}
+  GITHUB_APP_ID: {{ .Values.config.github.app.appID | required "config.github.app.appID is required" | quote }}
+  GITHUB_APP_SLUG: {{ .Values.config.github.app.appSlug | required "config.github.app.appSlug is required" | quote }}
+  # needed in order to process webhook events
+  OCTOBOX_BACKGROUND_JOBS_ENABLED: "true"
+  {{- end }}
+
   PERSONAL_ACCESS_TOKENS_ENABLED: {{ .Values.config.github.personalAccessTokensEnabled | quote }}
 
   {{- if .Values.config.github.restrictedAccess.enabled }}

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -43,7 +43,7 @@ spec:
             command: {{ .Values.cronjob.command }}
             args: {{ .Values.cronjob.args }}
             resources:
-              {{- toYaml .Values.resources | nindent 14 }}
+              {{- toYaml .Values.cronjob.resources | nindent 14 }}
             envFrom:
             - secretRef:
                 name: {{ include "octobox.secretName" . }}
@@ -55,15 +55,15 @@ spec:
             env:
             {{- .Values.extraEnvVars | toYaml | nindent 14 }}
             {{- end }}
-          {{- with .Values.nodeSelector }}
+          {{- with .Values.cronjob.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.affinity }}
+          {{- with .Values.cronjob.affinity }}
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.tolerations }}
+          {{- with .Values.cronjob.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "octobox.fullname" . }}-{{ .Values.cronjob.name }}
   labels:
     {{- include "octobox.labels" . | nindent 4 }}
+    role: notifications-sync
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
   concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         {{- include "octobox.selectorLabels" . | nindent 8 }}
+        role: notifications-sync
     spec:
       template:
         metadata:
@@ -23,6 +25,7 @@ spec:
           {{- end }}
           labels:
             {{- include "octobox.selectorLabels" . | nindent 12 }}
+            role: notifications-sync
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "octobox.fullname" . }}-{{ .Values.cronjob.name }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "octobox.selectorLabels" . | nindent 8 }}
+    spec:
+      template:
+        metadata:
+          {{- with .Values.cronjob.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "octobox.selectorLabels" . | nindent 12 }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          restartPolicy: {{ .Values.cronjob.restartPolicy }}
+          containers:
+          - name: {{ .Chart.Name }}-{{ .Values.cronjob.name }}
+            securityContext:
+              {{- toYaml .Values.securityContext | nindent 14 }}
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            command: {{ .Values.cronjob.command }}
+            args: {{ .Values.cronjob.args }}
+            resources:
+              {{- toYaml .Values.resources | nindent 14 }}
+            envFrom:
+            - secretRef:
+                name: {{ include "octobox.secretName" . }}
+                optional: false
+            - configMapRef:
+                name: {{ include "octobox.configMapName" . }}
+                optional: false
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -38,7 +38,7 @@ spec:
           - name: {{ .Chart.Name }}-{{ .Values.cronjob.name }}
             securityContext:
               {{- toYaml .Values.securityContext | nindent 14 }}
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            image: {{ include "octobox.image" . | quote }}
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command: {{ .Values.cronjob.command }}
             args: {{ .Values.cronjob.args }}

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -51,6 +51,10 @@ spec:
             - configMapRef:
                 name: {{ include "octobox.configMapName" . }}
                 optional: false
+            {{- if .Values.extraEnvVars }}
+            env:
+            {{- .Values.extraEnvVars | toYaml | nindent 14 }}
+            {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/charts/octobox/templates/cronjob.yaml
+++ b/charts/octobox/templates/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             securityContext:
               {{- toYaml .Values.securityContext | nindent 14 }}
             image: {{ include "octobox.image" . | quote }}
-            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            imagePullPolicy: {{ .Values.global.octobox.image.pullPolicy }}
             command: {{ .Values.cronjob.command }}
             args: {{ .Values.cronjob.args }}
             resources:

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "octobox.image" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.global.octobox.image.pullPolicy }}
           ports:
           - name: http
             containerPort: 3000

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "octobox.fullname" . }}
   labels:
     {{- include "octobox.labels" . | nindent 4 }}
+    role: server
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -11,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "octobox.selectorLabels" . | nindent 6 }}
+      role: server
   template:
     metadata:
       annotations:
@@ -21,6 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "octobox.selectorLabels" . | nindent 8 }}
+        role: server
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
     matchLabels:
       {{- include "octobox.selectorLabels" . | nindent 6 }}
@@ -35,7 +36,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "octobox.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: http

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "octobox.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "octobox.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: http
+            containerPort: 3000
+            protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+          - secretRef:
+              name: {{ include "octobox.secretName" . }}
+              optional: false
+          - configMapRef:
+              name: {{ include "octobox.configMapName" . }}
+              optional: false
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -13,8 +13,10 @@ spec:
       {{- include "octobox.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/octobox/templates/deployment.yaml
+++ b/charts/octobox/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
           - configMapRef:
               name: {{ include "octobox.configMapName" . }}
               optional: false
+          {{- if .Values.extraEnvVars }}
+          env:
+          {{- .Values.extraEnvVars | toYaml | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/octobox/templates/hpa.yaml
+++ b/charts/octobox/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "octobox.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/octobox/templates/ingress.yaml
+++ b/charts/octobox/templates/ingress.yaml
@@ -1,6 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "octobox.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $nginxFullname := "nginx-static-assets" -}}
+{{- with (set (deepCopy .) "Values" .Values.nginx) -}}
+{{- $nginxFullname := include "common.names.fullname" . -}}
+{{- end -}}
+{{- $nginxPort := .Values.nginx.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -31,11 +36,17 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-          {{- end }}
+        {{- if $.Values.nginx.enabled }}
+        {{- range $.Values.ingress.staticAssetsPrefixes }}
+        - path: {{ . | quote }}
+          backend:
+            serviceName: {{ $nginxFullname }}
+            servicePort: {{ $nginxPort }}
+        {{- end }}
+        {{- end }}
+        - path: /
+          backend:
+            serviceName: {{ $fullName }}
+            servicePort: {{ $svcPort }}
     {{- end }}
   {{- end }}

--- a/charts/octobox/templates/ingress.yaml
+++ b/charts/octobox/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "octobox.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/octobox/templates/pdb.yaml
+++ b/charts/octobox/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+    role: server
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "octobox.selectorLabels" . | nindent 6 }}
+      role: server
+{{- end }}

--- a/charts/octobox/templates/secret.yaml
+++ b/charts/octobox/templates/secret.yaml
@@ -27,6 +27,13 @@ data:
   GITHUB_CLIENT_ID: {{ .Values.config.github.oauth.clientID | required "config.github.oauth.clientID is required" | b64enc | quote }}
   GITHUB_CLIENT_SECRET: {{ .Values.config.github.oauth.clientSecret | required "config.github.oauth.clientSecret is required" | b64enc | quote }}
 
+  {{- if .Values.config.github.app }}
+  GITHUB_APP_CLIENT_ID: {{ .Values.config.github.app.clientID | required "config.github.app.clientID is required" | b64enc | quote }}
+  GITHUB_APP_CLIENT_SECRET: {{ .Values.config.github.app.clientSecret | required "config.github.app.clientSecret is required" | b64enc | quote }}
+  GITHUB_APP_JWT: {{ .Values.config.github.app.privateKey | required "config.github.app.privateKey is required" | b64enc | quote }}
+  GITHUB_WEBHOOK_SECRET: {{ .Values.config.github.app.webhookSecret | required "config.github.app.webhookSecret is required" | b64enc | quote }}
+  {{- end }}
+
   OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY: {{ .Values.config.octoboxAttributeEncryptionKey | required "config.octoboxAttributeEncryptionKey is required" | b64enc | quote }}
   SECRET_KEY_BASE: {{ .Values.config.secretKeyBase | required "config.secretKeyBase is required" | b64enc | quote }}
 {{- end }}

--- a/charts/octobox/templates/secret.yaml
+++ b/charts/octobox/templates/secret.yaml
@@ -10,12 +10,16 @@ data:
   {{- if .Values.config.database.username }}
   OCTOBOX_DATABASE_USERNAME: {{ .Values.config.database.username | b64enc | quote }}
   {{- else }}
-  OCTOBOX_DATABASE_USERNAME: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
+  {{- with (set (deepCopy .) "Values" .Values.postgresql) }}
+  OCTOBOX_DATABASE_USERNAME: {{ include "postgresql.username" . | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.config.database.password }}
   OCTOBOX_DATABASE_PASSWORD: {{ .Values.config.database.password | b64enc | quote }}
   {{- else }}
-  OCTOBOX_DATABASE_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+  {{- with (set (deepCopy .) "Values" .Values.postgresql) }}
+  OCTOBOX_DATABASE_PASSWORD: {{ include "postgresql.password" . | b64enc | quote }}
+  {{- end }}
   {{- end }}
 
   REDIS_URL: {{ include "octobox.redisURL" . | b64enc | quote }}

--- a/charts/octobox/templates/secret.yaml
+++ b/charts/octobox/templates/secret.yaml
@@ -7,23 +7,22 @@ metadata:
     {{- include "octobox.labels" . | nindent 4 }}
 type: Opaque
 data:
-  GITHUB_CLIENT_ID: {{ .Values.secrets.githubClientID | required "secrets.githubClientID is required" | b64enc | quote }}
-  GITHUB_CLIENT_SECRET: {{ .Values.secrets.githubClientSecret | required "secrets.githubClientSecret is required" | b64enc | quote }}
-
-  OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY: {{ .Values.secrets.octoboxAttributeEncryptionKey | required "secrets.octoboxAttributeEncryptionKey is required" | b64enc | quote }}
-
-  {{- if .Values.secrets.octoboxDatabaseUsername }}
-  OCTOBOX_DATABASE_USERNAME: {{ .Values.secrets.octoboxDatabaseUsername | b64enc | quote }}
+  {{- if .Values.config.database.username }}
+  OCTOBOX_DATABASE_USERNAME: {{ .Values.config.database.username | b64enc | quote }}
   {{- else }}
   OCTOBOX_DATABASE_USERNAME: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
   {{- end }}
-  {{- if .Values.secrets.octoboxDatabasePassword }}
-  OCTOBOX_DATABASE_PASSWORD: {{ .Values.secrets.octoboxDatabasePassword | b64enc | quote }}
+  {{- if .Values.config.database.password }}
+  OCTOBOX_DATABASE_PASSWORD: {{ .Values.config.database.password | b64enc | quote }}
   {{- else }}
   OCTOBOX_DATABASE_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
   {{- end }}
 
   REDIS_URL: {{ include "octobox.redisURL" . | b64enc | quote }}
 
-  SECRET_KEY_BASE: {{ .Values.secrets.secretKeyBase | required "secrets.secretKeyBase is required" | b64enc | quote }}
+  GITHUB_CLIENT_ID: {{ .Values.config.github.oauth.clientID | required "config.github.oauth.clientID is required" | b64enc | quote }}
+  GITHUB_CLIENT_SECRET: {{ .Values.config.github.oauth.clientSecret | required "config.github.oauth.clientSecret is required" | b64enc | quote }}
+
+  OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY: {{ .Values.config.octoboxAttributeEncryptionKey | required "config.octoboxAttributeEncryptionKey is required" | b64enc | quote }}
+  SECRET_KEY_BASE: {{ .Values.config.secretKeyBase | required "config.secretKeyBase is required" | b64enc | quote }}
 {{- end }}

--- a/charts/octobox/templates/secret.yaml
+++ b/charts/octobox/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+type: Opaque
+data:
+  GITHUB_CLIENT_ID: {{ .Values.secrets.githubClientID | required "secrets.githubClientID is required" | b64enc | quote }}
+  GITHUB_CLIENT_SECRET: {{ .Values.secrets.githubClientSecret | required "secrets.githubClientSecret is required" | b64enc | quote }}
+
+  OCTOBOX_ATTRIBUTE_ENCRYPTION_KEY: {{ .Values.secrets.octoboxAttributeEncryptionKey | required "secrets.octoboxAttributeEncryptionKey is required" | b64enc | quote }}
+
+  {{- if .Values.secrets.octoboxDatabaseUsername }}
+  OCTOBOX_DATABASE_USERNAME: {{ .Values.secrets.octoboxDatabaseUsername | b64enc | quote }}
+  {{- else }}
+  OCTOBOX_DATABASE_USERNAME: {{ .Values.postgresql.postgresqlUsername | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.octoboxDatabasePassword }}
+  OCTOBOX_DATABASE_PASSWORD: {{ .Values.secrets.octoboxDatabasePassword | b64enc | quote }}
+  {{- else }}
+  OCTOBOX_DATABASE_PASSWORD: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+  {{- end }}
+
+  REDIS_URL: {{ include "octobox.redisURL" . | b64enc | quote }}
+
+  SECRET_KEY_BASE: {{ .Values.secrets.secretKeyBase | required "secrets.secretKeyBase is required" | b64enc | quote }}
+{{- end }}

--- a/charts/octobox/templates/service.yaml
+++ b/charts/octobox/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "octobox.fullname" . }}
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "octobox.selectorLabels" . | nindent 4 }}

--- a/charts/octobox/templates/tests/test-connection.yaml
+++ b/charts/octobox/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "octobox.fullname" . }}-test-connection"
+  labels:
+    {{- include "octobox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "octobox.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -171,6 +171,31 @@ extraEnvVars: []
 #     fieldRef:
 #       fieldPath: fieldPath
 
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## Pod Disruption Budget configuration
+## (only sensible if replicaCount > 1)
+pdb:
+  create: false
+
+  ## Min number of pods that must still be available after the eviction
+  minAvailable: 1
+
+  ## Max number of pods that can be unavailable after the eviction
+  # maxUnavailable: 1
+
 ## cronjob for server-side notification syncs
 ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#scheduling-server-side-notification-syncs
 cronjob:
@@ -190,6 +215,20 @@ cronjob:
 
   podAnnotations: {}
 
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 ## TODO: add network policies
 
 service:
@@ -207,6 +246,8 @@ ingress:
   #  - secretName: octobox-tls
   #    hosts:
   #    - octobox.local
+
+  ## Paths to serve from nginx instead of octobox
   staticAssetsPrefixes:
   - /assets/
   - /android-icon-
@@ -218,26 +259,12 @@ ingress:
   - /ms-icon-
   - /robots.txt
 
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 ## nginx for serving static assets
 nginx:
@@ -267,6 +294,16 @@ nginx:
       image: {{ include "octobox.image" $ | quote }}
       imagePullPolicy: {{ $.Values.global.octobox.image.pullPolicy }}
       command: [ "cp", "-r", "/usr/src/app/public/.", "/static-assets" ]
+
+      # specify some default requests/limits (not customizable),
+      # better than none, also probably doesn't need much customization
+      resources:
+        requests:
+          cpu: 10m
+          memory: 30Mi
+        limits:
+          cpu: 30m
+          memory: 80Mi
       volumeMounts:
       - mountPath: /static-assets
         name: static-assets

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -67,7 +67,7 @@ config:
     # domain: https://github.mycompany.com
 
     ## GitHub OAuth settings
-    ## register a new OAuth app under https://github.com/settings/applications/new
+    ## (register a new OAuth app under https://github.com/settings/applications/new)
     oauth:
       ## defaults to "notifications" or "notifications, read:org" if restricted access is enabled
       ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#customizing-the-scopes-on-github
@@ -76,6 +76,25 @@ config:
       ## oauth client ID and client secret of your GitHub OAuth app
       clientID: ""
       clientSecret: ""
+
+    ## GitHub App settings (optional/additional to oauth)
+    ## (register a new GitHub app under https://github.com/settings/apps/new)
+    ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#running-octobox-as-a-github-app
+    app: {}
+      ## App ID of your GitHub App
+      # appID: ""
+      ## last path segment of public URL
+      # appSlug: ""
+
+      ## client ID and client secret of your GitHub App
+      # clientID: ""
+      # clientSecret: ""
+
+      ## contents of private key to sign access token requests
+      # privateKey: ""
+
+      ## webhook secret for authenticating GitHub requests
+      # webhookSecret: ""
 
     ## allow users to authenticate using personal access tokens
     ## https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#using-personal-access-tokens
@@ -160,6 +179,8 @@ cronjob:
   - "tasks:sync_notifications"
 
   podAnnotations: {}
+
+## TODO: add network policies
 
 service:
   type: ClusterIP

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -1,0 +1,172 @@
+# Default values for octobox.
+
+replicaCount: 1
+
+image:
+  repository: octoboxio/octobox
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 60
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# don't create ConfigMap and use an existing one instead
+# existingConfigMap: octobox
+
+## TODO: add checksum to deployment spec for configmap contents
+config:
+  database: postgres
+
+  ## overwrite default postgres connection params
+  ## will be defaulted to values from postgresql subchart
+  # octoboxDatabaseHost:
+  # octoboxDatabasePort:
+  # octoboxDatabaseName:
+
+  ## see https://github.com/octobox/octobox/blob/eb9e23795c87150f2b5e711c1cd5b5980850e5ba/docs/INSTALLATION.md#downloading-subjects
+  fetchSubject: true
+
+  ## defaults to "notifications" or "notifications, read:org" if restricted access is enabled
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#customizing-the-scopes-on-github
+  githubScope: "notifications, read:org"
+
+  ## setup octobox for GitHub Enterprise
+  # githubDomain: https://github.foobar.com
+
+  gaAnalyticsID: ''
+  minimumRefreshInterval: 5
+  openInSameTab: true
+  personalAccessTokensEnabled: false
+  railsEnv: production
+
+  ## TODO: replace with nginx our something similar
+  railsServeStaticAssets: true
+
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#live-updates
+  pushNotifications: false
+
+  ## TODO calculate from ingress.hosts
+  # websocketAllowedOrigins:
+  # - http://localhost:3000
+  # - https://localhost:3000
+
+  ## restrict access to certain GitHub org or team members
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#limiting-access
+  restrictedAccess:
+    enabled: false
+    githubOrganizationID: ""
+    githubTeamID: ""
+
+  ## configure IDs
+  # adminGithubIDs:
+  # - "12345678"
+
+## don't create Secret and use an existing one instead
+# existingSecret: octobox
+
+## TODO: add checksum to deployment spec for secret contents
+secrets:
+  githubClientID: ""
+  githubClientSecret: ""
+
+  ## random 32 byte encryption key
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#encryption-key
+  octoboxAttributeEncryptionKey: ""
+
+  ## overwrite default postgres connection params
+  ## will be defaulted to values from postgresql subchart
+  # octoboxDatabaseUsername:
+  # octoboxDatabasePassword:
+
+  ## overwrite default redis connection params
+  ## will be defaulted to values from redis subchart
+  # redisURL: redis://user:password@redis-master.octobox
+
+  ## random 32 byte key (required for production environment)
+  secretKeyBase: ""
+
+cronjob:
+  enabled: true
+  name: notifications
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  restartPolicy: OnFailure
+  schedule: "*/5 * * * *"
+  command:
+  - /usr/local/bin/rake
+  args:
+  - "tasks:sync_notifications"
+  podAnnotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: octobox.local
+      paths: []
+  tls: []
+  #  - secretName: octobox-tls
+  #    hosts:
+  #      - octobox.local
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+postgresql:
+  fullnameOverride: postgres
+
+redis:
+  fullnameOverride: redis

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -5,7 +5,8 @@ replicaCount: 1
 image:
   repository: octoboxio/octobox
   pullPolicy: IfNotPresent
-  tag: "latest"
+  ## tag or sha ref
+  tag: latest
 
 imagePullSecrets: []
 nameOverride: ""
@@ -23,6 +24,8 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+minReadySeconds: 0
 
 livenessProbe:
   httpGet:
@@ -132,7 +135,6 @@ config:
   pushNotifications: false
 
   ## allowed origins for websocket connections for live updates
-  ## TODO calculate from ingress.hosts
   websocketAllowedOrigins: []
   # - http://localhost:3000
   # - https://localhost:3000
@@ -199,6 +201,10 @@ affinity: {}
 
 postgresql:
   fullnameOverride: postgres
+
+  global:
+    postgresql:
+      postgresqlDatabase: octobox
 
 redis:
   fullnameOverride: redis

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -38,93 +38,125 @@ readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
 
-# don't create ConfigMap and use an existing one instead
+## don't create ConfigMap and use an existing one instead
 # existingConfigMap: octobox
-
-## TODO: add checksum to deployment spec for configmap contents
-config:
-  database: postgres
-
-  ## overwrite default postgres connection params
-  ## will be defaulted to values from postgresql subchart
-  # octoboxDatabaseHost:
-  # octoboxDatabasePort:
-  # octoboxDatabaseName:
-
-  ## see https://github.com/octobox/octobox/blob/eb9e23795c87150f2b5e711c1cd5b5980850e5ba/docs/INSTALLATION.md#downloading-subjects
-  fetchSubject: true
-
-  ## defaults to "notifications" or "notifications, read:org" if restricted access is enabled
-  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#customizing-the-scopes-on-github
-  githubScope: "notifications, read:org"
-
-  ## setup octobox for GitHub Enterprise
-  # githubDomain: https://github.foobar.com
-
-  gaAnalyticsID: ''
-  minimumRefreshInterval: 5
-  openInSameTab: true
-  personalAccessTokensEnabled: false
-  railsEnv: production
-
-  ## TODO: replace with nginx our something similar
-  railsServeStaticAssets: true
-
-  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#live-updates
-  pushNotifications: false
-
-  ## TODO calculate from ingress.hosts
-  # websocketAllowedOrigins:
-  # - http://localhost:3000
-  # - https://localhost:3000
-
-  ## restrict access to certain GitHub org or team members
-  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#limiting-access
-  restrictedAccess:
-    enabled: false
-    githubOrganizationID: ""
-    githubTeamID: ""
-
-  ## configure IDs
-  # adminGithubIDs:
-  # - "12345678"
 
 ## don't create Secret and use an existing one instead
 # existingSecret: octobox
 
-## TODO: add checksum to deployment spec for secret contents
-secrets:
-  githubClientID: ""
-  githubClientSecret: ""
+## Octobox config
+config:
+  ## overwrite default postgres connection params
+  ## will be defaulted to values from postgresql subchart
+  database: {}
+    # host:
+    # port:
+    # databaseName:
+    # username:
+    # password:
+
+  ## overwrite default redis connection URL
+  ## will be defaulted to values from redis subchart
+  # redisURL: redis://user:password@redis-master.octobox
+
+  github:
+    ## setup octobox for GitHub Enterprise instead of github.com
+    # domain: https://github.mycompany.com
+
+    ## GitHub OAuth settings
+    ## register a new OAuth app under https://github.com/settings/applications/new
+    oauth:
+      ## defaults to "notifications" or "notifications, read:org" if restricted access is enabled
+      ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#customizing-the-scopes-on-github
+      # scope: "notifications, read:org"
+
+      ## oauth client ID and client secret of your GitHub OAuth app
+      clientID: ""
+      clientSecret: ""
+
+    ## allow users to authenticate using personal access tokens
+    ## https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#using-personal-access-tokens
+    personalAccessTokensEnabled: false
+
+    ## restrict access to certain GitHub org or team members
+    ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#limiting-access
+    restrictedAccess:
+      enabled: false
+
+      ## get via `curl https://api.github.com/orgs/<org_name>`
+      organizationID: ""
+
+      ## organizationID needs to be set if restricting access to a team
+      ## get via `curl https://api.github.com/orgs/<org_name>/teams' (authentication needed)
+      teamID: ""
+
+    ## configure IDs
+    ## get via `curl https://api.github.com/users/<username>`
+    adminIDs: []
+    # - "12345678"
+
+  ## download extra information about the subject of each notification
+  ## (needed for thread view)
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#downloading-subjects
+  fetchSubject: true
+
+  ## download comments on the subject of each notification
+  ## (needed for thread view)
+  includeComments: true
+
+  ## if thread view is disabled, open links in same tab instead of new one
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#open-links-in-the-same-tab
+  openInSameTab: true
+
+  ## allow users to set auto-refresh interval, lowest interval that can be set
+  ## if set to 0, disable auto-refreshing notifications
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#allowing-periodic-notification-refreshes
+  minimumRefreshInterval: 5
+
+  railsEnv: production
+
+  ## configure octobox to serve static assests on its own instead of relying on some external webserver
+  ## TODO: host static assets on nginx
+  railsServeStaticAssets: true
 
   ## random 32 byte encryption key
   ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#encryption-key
   octoboxAttributeEncryptionKey: ""
 
-  ## overwrite default postgres connection params
-  ## will be defaulted to values from postgresql subchart
-  # octoboxDatabaseUsername:
-  # octoboxDatabasePassword:
-
-  ## overwrite default redis connection params
-  ## will be defaulted to values from redis subchart
-  # redisURL: redis://user:password@redis-master.octobox
-
   ## random 32 byte key (required for production environment)
   secretKeyBase: ""
 
+  ## enable live updates for currently viewed notifications
+  ## (needs redis to be enabled)
+  ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#live-updates
+  pushNotifications: false
+
+  ## allowed origins for websocket connections for live updates
+  ## TODO calculate from ingress.hosts
+  websocketAllowedOrigins: []
+  # - http://localhost:3000
+  # - https://localhost:3000
+
+  ## enable Google Analytics tracking
+  googleAnalyticsID: ''
+
+## cronjob for server-side notification syncs
+## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#scheduling-server-side-notification-syncs
 cronjob:
   enabled: true
   name: notifications
+
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Replace
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
+
   restartPolicy: OnFailure
-  schedule: "*/5 * * * *"
   command:
   - /usr/local/bin/rake
   args:
   - "tasks:sync_notifications"
+
   podAnnotations: {}
 
 service:
@@ -136,13 +168,13 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: octobox.local
-      paths: []
+  hosts: []
+  # - host: octobox.local
+  #   paths: []
   tls: []
   #  - secretName: octobox-tls
   #    hosts:
-  #      - octobox.local
+  #    - octobox.local
 
 resources: {}
   # limits:

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -2,11 +2,13 @@
 
 replicaCount: 1
 
-image:
-  repository: octoboxio/octobox
-  pullPolicy: IfNotPresent
-  ## tag or sha ref
-  tag: latest
+global:
+  octobox:
+    image:
+      repository: octoboxio/octobox
+      pullPolicy: IfNotPresent
+      ## tag or sha ref
+      tag: latest
 
 imagePullSecrets: []
 nameOverride: ""
@@ -137,9 +139,8 @@ config:
 
   railsEnv: production
 
-  ## configure octobox to serve static assests on its own instead of relying on some external webserver
-  ## TODO: host static assets on nginx
-  railsServeStaticAssets: true
+  ## configure octobox to serve static assests on its own instead of external nginx
+  railsServeStaticAssets: false
 
   ## random 32 byte encryption key
   ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#encryption-key
@@ -202,11 +203,20 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts: []
   # - host: octobox.local
-  #   paths: []
   tls: []
   #  - secretName: octobox-tls
   #    hosts:
   #    - octobox.local
+  staticAssetsPrefixes:
+  - /assets/
+  - /android-icon-
+  - /apple-icon
+  - /browserconfig.xml
+  - /favicon
+  - /icon/
+  - /manifest.json
+  - /ms-icon-
+  - /robots.txt
 
 resources: {}
   # limits:
@@ -228,6 +238,62 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## nginx for serving static assets
+nginx:
+  enabled: true
+  fullnameOverride: nginx-static-assets
+
+  commonLabels:
+    role: static-assets
+
+  podLabels:
+    role: static-assets
+
+  replicaCount: 1
+
+  minReadySeconds: 0
+
+  extraVolumeMounts:
+  - name: static-assets
+    mountPath: /usr/src/app/public
+
+  extraVolumes:
+  - name: static-assets
+    emptyDir: {}
+
+  initContainers: |
+    - name: octobox-static-assets
+      image: {{ include "octobox.image" $ | quote }}
+      imagePullPolicy: {{ $.Values.global.octobox.image.pullPolicy }}
+      command: [ "cp", "-r", "/usr/src/app/public/.", "/static-assets" ]
+      volumeMounts:
+      - mountPath: /static-assets
+        name: static-assets
+
+  serverBlock: |-
+    server {
+      listen 8080;
+
+      root /usr/src/app/public;
+      try_files $uri =404;
+      access_log off;
+      gzip on;
+      gzip_types *;
+
+      location ~ ^/(assets/|android-icon-|apple-icon|favicon|icon/|ms-icon-) {
+        expires 1y;
+        add_header Cache-Control "public,max-age=31536000,immutable";
+      }
+
+      location ~ ^/(browserconfig.xml|manifest.json|robots.txt) {
+        expires 6h;
+        add_header Cache-Control "public,max-age=21600,immutable";
+      }
+    }
+
+  service:
+    type: ClusterIP
 
 postgresql:
   fullnameOverride: postgres

--- a/charts/octobox/values.yaml
+++ b/charts/octobox/values.yaml
@@ -161,6 +161,15 @@ config:
   ## enable Google Analytics tracking
   googleAnalyticsID: ''
 
+## extra env vars to add to octobox containers
+extraEnvVars: []
+# - name: name
+#   value: value
+# - name: other_name
+#   valueFrom:
+#     fieldRef:
+#       fieldPath: fieldPath
+
 ## cronjob for server-side notification syncs
 ## see https://github.com/octobox/octobox/blob/master/docs/INSTALLATION.md#scheduling-server-side-notification-syncs
 cronjob:


### PR DESCRIPTION
Adds a first version of a helm chart for [Octobox](https://github.com/octobox/octobox).
It includes flags/values for a lot of configuration options from Octobox, including for example restricted access settings, GitHub enterprise domain and GitHub App settings (see `values.yaml` for more details, `README.md` is still missing).

It uses bitnami's charts for postgres, redis and nginx (used for serving static assets).